### PR TITLE
std.err !- stderr, fixing so errors output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,12 @@ program
       if (fs.existsSync(__dirname + file)) {
         exec('git add ' + file, function(error, stdout, stderr) {
           if (error) console.log(error);
-          if (stderr) console.log(std.err);
+          if (stderr) console.log(stderr);
         });
       } else {
         exec('git rm ' + file, function(error, stdout, stderr) {
           if (error) console.log(error);
-          if (stderr) console.log(std.err);
+          if (stderr) console.log(stderr);
         });
       }
     });


### PR DESCRIPTION
std.err should be stderr?

`C:\Users\scott\Desktop\giddytest>giddy stage readme.txt
Aww yeah! [ 'readme.txt' ] have been staged!
{ Error: Command failed: git rm readme.txt
fatal: pathspec 'readme.txt' did not match any files

    at ChildProcess.exithandler (child_process.js:204:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:886:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
  killed: false,
  code: 128,
  signal: null,
  cmd: 'git rm readme.txt' }
C:\Users\scott\AppData\Roaming\npm\node_modules\giddy\src\index.js:48
          if (stderr) console.log(std.err);
                                  ^`